### PR TITLE
Setup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ node_js:
   - "8"
 sudo: true
 dist: trusty
+addons:
+  chrome: stable
 
 script:
   - npm run lint
+  - npm run test:headless
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
   - "8"
-sudo: true
 dist: trusty
+sudo: false
+
 addons:
   chrome: stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ node_js:
 dist: trusty
 sudo: false
 
+cache:
+  directories:
+    - node_modules
+
 addons:
   chrome: stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ script:
   - npm run lint
   - npm run test:headless
   - npm run build
+  - xvfb-run npm run e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "8"
+sudo: true
+dist: trusty
+
+script:
+  - npm run lint
+  - npm run build

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -28,6 +28,18 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
+    customLaunchers: {
+      ChromeHeadless: {
+        base: 'Chrome',
+        flags: [
+          '--headless',
+          '--disable-gpu',
+          '--no-sandbox',
+          // Without a remote debugging port, Google Chrome exits immediately.
+          '--remote-debugging-port=9222',
+        ],
+      }
+    },
     singleRun: false
   });
 };

--- a/config/protractor.conf.js
+++ b/config/protractor.conf.js
@@ -9,7 +9,10 @@ exports.config = {
     '../e2e/**/*.e2e-spec.ts'
   ],
   capabilities: {
-    'browserName': 'chrome'
+    'browserName': 'chrome',
+     chromeOptions: {
+      args: ['--no-sandbox']
+    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "ng serve",
     "build": "ng build --prod",
     "test": "ng test",
+    "test:headless": "ng test --single-run --progress false --browser ChromeHeadless",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "release": "standard-version"


### PR DESCRIPTION
[Travis CI](https://travis-ci.org/) offers simple continuous integration with GitHub projects. 

## Stages

Using Travis, with each push we want to:

- run unit tests
- lint code
- generate build
- run e2e tests

## Configuration

### Angular

- Configure [Karma](https://github.com/karma-runner/karma) to use headless Chrome for testing
- Add npm script `npm run test:headless` for this
- Disable sandboxing in the protractor config

### Travis

- Use the Linux Trusty build
- Disable sudo to containerize builds
- Enable the Chrome Addon
- Use `xvfb-run` wrapper to run e2e tests

## Not necessary

If you scour the internet, you will find texts about installing angular globally, adding chrome and xvfb with `apt-get`, running xvfb directly from `/etc/init.d/`, setting chrome location in the environment variable and more.  **Just DON'T**. 

Travis did the hard work for you.

## Resources

- [Google Developers: Getting Started with Headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome)
- [Travis CI: Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/)
- [Travis CI: The Trusty Build Environment](https://docs.travis-ci.com/user/reference/trusty/)
- [Travis CI: GUI and Headless Browser Testing > Using the xvfb-run wrapper](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-the-xvfb-run-wrapper)
- [Travis CI: Google Chrome > Sandboxing](https://docs.travis-ci.com/user/chrome#Sandboxing)


